### PR TITLE
Backport upstream fixes for atan, needed for the maxima tests to pass

### DIFF
--- a/recipe/atan.patch
+++ b/recipe/atan.patch
@@ -1,0 +1,123 @@
+diff --git a/src/c/numbers/atan.d b/src/c/numbers/atan.d
+index bfcd008..3b99a31 100644
+--- a/src/c/numbers/atan.d
++++ b/src/c/numbers/atan.d
+@@ -2,11 +2,12 @@
+ /* vim: set filetype=c tabstop=2 shiftwidth=2 expandtab: */
+ 
+ /*
+- * atan1.d - Trascendental functions: arc tangent
++ * atan.d - Trascendental functions: arc tangent
+  *
+  * Copyright (c) 1984 Taiichi Yuasa and Masami Hagiya
+  * Copyright (c) 1990 Giuseppe Attardi
+  * Copyright (c) 2001 Juan Jose Garcia Ripoll
++ * Copyright (c) 2016 Daniel Kochmański
+  *
+  * See file 'LICENSE' for the copyright details.
+  *
+@@ -19,68 +20,6 @@
+ 
+ #pragma STDC FENV_ACCESS ON
+ 
+-static double
+-ecl_atan2_double(double y, double x)
+-{
+-  if (signbit(x)) {
+-    if (signbit(y)) {
+-      return -ECL_PI_D + atan(-y / -x);
+-    } else if (y == 0) {
+-      return ECL_PI_D;
+-    } else {
+-      return ECL_PI_D - atan(y / -x);
+-    }
+-  } else if (x == 0) {
+-    if (signbit(y)) {
+-      return -ECL_PI2_D;
+-    } else if (y == 0) {
+-      return x / y;  /* Produces a NaN */
+-    } else {
+-      return ECL_PI2_D;
+-    }
+-  } else {
+-    if (signbit(y)) {
+-      return -atan(-y / x);
+-    } else if (y == 0) {
+-      return (double)0;
+-    } else {
+-      return atan(y / x);
+-    }
+-  }
+-}
+-
+-#ifdef ECL_LONG_FLOAT
+-static long double
+-ecl_atan2_long_double(long double y, long double x)
+-{
+-  if (signbit(x)) {
+-    if (signbit(y)) {
+-      return -ECL_PI_L + atanl(-y / -x);
+-    } else if (y == 0) {
+-      return ECL_PI_L;
+-    } else {
+-      return ECL_PI_L - atanl(y / -x);
+-    }
+-  } else if (x == 0) {
+-    if (signbit(y)) {
+-      return -ECL_PI2_L;
+-    } else if (y == 0) {
+-      return x / y;  /* Produces a NaN */
+-    } else {
+-      return ECL_PI2_L;
+-    }
+-  } else {
+-    if (signbit(y)) {
+-      return -atanl(-y / x);
+-    } else if (y == 0) {
+-      return (long double)0;
+-    } else {
+-      return atanl(y / x);
+-    }
+-  }
+-}
+-#endif
+-
+ cl_object
+ ecl_atan2(cl_object y, cl_object x)
+ {
+@@ -93,13 +32,12 @@ ecl_atan2(cl_object y, cl_object x)
+     if (tx < ty)
+       tx = ty;
+     if (tx == t_longfloat) {
+-      long double d = ecl_atan2_long_double(ecl_to_long_double(y),
+-                                            ecl_to_long_double(x));
++      long double d = atan2l(ecl_to_long_double(y), ecl_to_long_double(x));
+       output = ecl_make_long_float(d);
+     } else {
+       double dx = ecl_to_double(x);
+       double dy = ecl_to_double(y);
+-      double dz = ecl_atan2_double(dy, dx);
++      double dz = atan2(dy, dx);
+       if (tx == t_doublefloat) {
+         output = ecl_make_double_float(dz);
+       } else {
+@@ -109,7 +47,7 @@ ecl_atan2(cl_object y, cl_object x)
+ #else
+     double dy = ecl_to_double(y);
+     double dx = ecl_to_double(x);
+-    double dz = ecl_atan2_double(dy, dx);
++    double dz = atan2(dy, dx);
+     if (ECL_DOUBLE_FLOAT_P(x) || ECL_DOUBLE_FLOAT_P(y)) {
+       output = ecl_make_double_float(dz);
+     } else {
+@@ -149,8 +87,8 @@ ecl_atan1(cl_object y)
+ 
+ @(defun atan (x &optional (y OBJNULL))
+   @
+-  /* INV: type check in ecl_atan() & ecl_atan2() */
+-  /* FIXME ecl_atan() and ecl_atan2() produce generic errors
++  /* INV: type check in ecl_atan1() & ecl_atan2() */
++  /* FIXME ecl_atan1() and ecl_atan2() produce generic errors
+      without recovery and function information. */
+   if (y == OBJNULL) {
+     @(return ecl_atan1(x));

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,12 @@ source:
     - write_error.patch
     # https://gitlab.com/embeddable-common-lisp/ecl/commit/6be9cb9dee2fc8df59604aa28413625898e70945.patch
     - fix_osx_runtime_path.patch
+    # Backport changes from upstream to the atan implementation--this fixes a
+    # bug that turns up in maxima.
+    - atan.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
See my explanation of the issue in conda-forge/staged-recipes#2621.  It should be possible to remove this patch after the next ECL release.